### PR TITLE
Fix pdf saving

### DIFF
--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -95,10 +95,10 @@ abstract class AbstractResponse
                 throw new SzamlaAgentException(SzamlaAgentException::DOCUMENT_DATA_IS_MISSING);
             }
 
-            if (!empty($pdfData)) {
+            if (!empty($this->pdfFile)) {
                 if ($this->agent->isPdfFileSaveable()) {
                     $realPath = $this->getPdfFileName();
-                    $isSaved = Storage::disk('payment')->put($realPath, $pdfData);
+                    $isSaved = Storage::disk('payment')->put($realPath, $this->pdfFile);
 
                     if ($isSaved) {
                         Log::channel('szamlazzhu')->debug(SzamlaAgentException::PDF_FILE_SAVE_SUCCESS, ['path' => $realPath]);

--- a/src/Response/InvoiceResponse.php
+++ b/src/Response/InvoiceResponse.php
@@ -75,7 +75,7 @@ class InvoiceResponse extends AbstractResponse
             $pdfFile = '';
         }
         if ($this->isPdfResponse($this->getData()['result']) && !empty($pdfFile)) {
-            $this->pdfFile = base64_decode($this->$pdfFile);
+            $this->pdfFile = base64_decode($pdfFile);
         }
 
         if (!$this->hasError()) {


### PR DESCRIPTION
This pull request updates the handling of PDF file saving in the response classes to fix an issue with saving pdf file of generated invoices.

### Changes to PDF file handling:

* [`src/Response/AbstractResponse.php`](diffhunk://#diff-5c1bb95bbc973e12670bf69eac5bb1ce20b2c0b5640bc1855665136f2b00254aL98-R101): Updated the `parseHttpResponse` method to use the `pdfFile` property instead of the `$pdfData` variable when saving the PDF file

* [`src/Response/InvoiceResponse.php`](diffhunk://#diff-c70ff90d3af21f02f9cd2c5e162190fede33135fd91b900d166d74077cf8de21L78-R78): Fixed a bug in the `parseData` method by correcting the variable used in the `base64_decode` function from `$this->$pdfFile` to `$pdfFile`, preventing null being passed to base64_decode.
