### PR TITLE
fix/issue-11

### DIFF
--- a/src/Header/ReverseInvoiceHeader.php
+++ b/src/Header/ReverseInvoiceHeader.php
@@ -61,10 +61,10 @@ class ReverseInvoiceHeader extends InvoiceHeader
         $data['szamlaszam'] = $this->getInvoiceNumber();
 
         if (!empty($this->issueDate)) {
-            $data['keltDatum'] = $this->issueDate;
+            $data['keltDatum'] = $this->issueDate->format('Y-m-d');
         }
         if (!empty($this->fulfillment)) {
-            $data['teljesitesDatum'] = $this->fulfillment;
+            $data['teljesitesDatum'] = $this->fulfillment->format('Y-m-d');
         }
         if (!empty($this->comment)) {
             $data['megjegyzes'] = $this->comment;

--- a/tests/Feature/DocumentCreationTest.php
+++ b/tests/Feature/DocumentCreationTest.php
@@ -2,6 +2,7 @@
 
 use Omisai\Szamlazzhu\Document\Invoice\Invoice;
 use Omisai\Szamlazzhu\Document\Invoice\PrePaymentInvoice;
+use Omisai\Szamlazzhu\Document\Invoice\ReverseInvoice;
 use Omisai\Szamlazzhu\Document\Receipt\Receipt;
 use Omisai\Szamlazzhu\SzamlaAgent;
 use Omisai\Szamlazzhu\SzamlaAgentException;
@@ -50,6 +51,38 @@ it('creates a receipt', function () {
     $receipt->setSeller($seller);
     $receipt->setItems([$receiptItem]);
     $response = $agent->generateReceipt($receipt);
+    expect($response->isSuccess())
+        ->toBeTrue()
+        ->not->toThrow(SzamlaAgentException::class);
+})->skipIfConfigNotSet('szamlazzhu.api_key');
+
+it('creates a reverse invoice for an original invoice', function () {
+    $agent = SzamlaAgent::createWithAPIkey(config('szamlazzhu.api_key'), false);
+
+    $originalInvoiceHeader = makeInvoiceHeader();
+    $seller = makeSeller();
+    $buyer = makeBuyer('Reverse Smith');
+    $invoiceItem = makeInvoiceItem();
+    $originalInvoice = new Invoice(Invoice::INVOICE_TYPE_E_INVOICE);
+    $originalInvoice->setHeader($originalInvoiceHeader);
+    $originalInvoice->setSeller($seller);
+    $originalInvoice->setBuyer($buyer);
+    $originalInvoice->setItems([$invoiceItem]);
+    $originalResponse = $agent->generateInvoice($originalInvoice);
+
+    expect($originalResponse->isSuccess())->toBeTrue();
+
+    $invoiceDocument = new ReverseInvoice(Invoice::INVOICE_TYPE_E_INVOICE);
+    $header = $invoiceDocument->getHeader();
+    $header->setInvoiceNumber($originalResponse->getInvoiceNumber());
+
+    $invoiceDocument
+        ->setHeader($header)
+        ->setSeller($seller)
+        ->setBuyer($buyer);
+
+    $response = $agent->generateReverseInvoice($invoiceDocument);
+
     expect($response->isSuccess())
         ->toBeTrue()
         ->not->toThrow(SzamlaAgentException::class);

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -8,6 +8,7 @@ use Omisai\Szamlazzhu\Header\InvoiceHeader;
 use Omisai\Szamlazzhu\Header\PrePaymentInvoiceHeader;
 use Omisai\Szamlazzhu\Header\ProformaHeader;
 use Omisai\Szamlazzhu\Header\ReceiptHeader;
+use Omisai\Szamlazzhu\Header\ReverseInvoiceHeader;
 use Omisai\Szamlazzhu\Item\InvoiceItem;
 use Omisai\Szamlazzhu\Item\ReceiptItem;
 use Omisai\Szamlazzhu\Language;
@@ -52,6 +53,19 @@ function makePrePaymentInvoiceHeader()
     $header->setIssueDate(Carbon::now());
     $header->setFulfillment(Carbon::now());
     $header->setPaymentDue(Carbon::now()->addDays(SzamlaAgentUtil::DEFAULT_ADDED_DAYS));
+    $header->setPaymentMethod(PaymentMethod::PAYMENT_METHOD_BANKCARD);
+    $header->setCurrency(Currency::EUR);
+    $header->setLanguage(Language::EN);
+    $header->setExchangeBank('MNB');
+    $header->setPaid(true);
+
+    return $header;
+}
+
+function makeReverseInvoiceHeader($type = null)
+{
+    $header = new ReverseInvoiceHeader($type ?? Invoice::INVOICE_TYPE_E_INVOICE);
+    $header->setIssueDate(Carbon::now());
     $header->setPaymentMethod(PaymentMethod::PAYMENT_METHOD_BANKCARD);
     $header->setCurrency(Currency::EUR);
     $header->setLanguage(Language::EN);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,8 +25,11 @@ abstract class TestCase extends OrchestraTestCase
     protected function resolveApplicationEnvironmentVariables($app)
     {
         if (property_exists($this, 'loadEnvironmentVariables') && $this->loadEnvironmentVariables === true) {
-            $app->useEnvironmentPath(__DIR__.'/..');
-            $app->make('Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables')->bootstrap($app);
+            $envPath = __DIR__.'/..';
+            if (file_exists($envPath.'/.env') || file_exists($envPath.'/.env.testing')) {
+                $app->useEnvironmentPath($envPath);
+                $app->make('Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables')->bootstrap($app);
+            }
         }
     }
 }

--- a/tests/Unit/LanguageTest.php
+++ b/tests/Unit/LanguageTest.php
@@ -38,10 +38,14 @@ describe('Language Enum', function () {
             ->toContain('fr')
             ->toContain('es')
             ->toContain('cz')
-            ->toContain('pl');
+            ->toContain('pl')
+            ->toContain('bg')
+            ->toContain('nl')
+            ->toContain('ru')
+            ->toContain('si');
     });
 
-    it('has exactly 11 languages', function () {
-        expect(Language::cases())->toHaveCount(11);
+    it('has exactly 15 languages', function () {
+        expect(Language::cases())->toHaveCount(15);
     });
 });


### PR DESCRIPTION
This pull request adds tests for creating reverse invoices, as well as fixes date formatting in the reverse invoice header. The most important changes are grouped below:

### Reverse Invoice Testing

* Added a test case to `DocumentCreationTest.php` that verifies the creation of a reverse invoice for an original invoice, including generating the original invoice and then creating the reverse invoice using the original's invoice number.
* Imported the `ReverseInvoice` class in `DocumentCreationTest.php` to support the new test.
* Imported the `ReverseInvoiceHeader` class in `Helpers.php` and added a `makeReverseInvoiceHeader()` helper function to easily create reverse invoice headers for tests. [[1]](diffhunk://#diff-67d98e0a301d65e56d811178712253bf62ba76bc6792aabe8a37f7d2300434f0R11) [[2]](diffhunk://#diff-67d98e0a301d65e56d811178712253bf62ba76bc6792aabe8a37f7d2300434f0R65-R77)

### Bug Fixes

* Updated the `buildXmlData` method in `ReverseInvoiceHeader.php` to correctly format the `issueDate` and `fulfillment` fields as `'Y-m-d'` strings, ensuring proper XML serialization.